### PR TITLE
Adjust city rendering to consider projection values

### DIFF
--- a/city-finder.js
+++ b/city-finder.js
@@ -9,15 +9,16 @@ const getCitiesForState = (state) => {
       return getCoordinatesForCities(state, incidentCities)
     })
     .then(response => {
-      console.log(response)
+      console.log(response.map(cities => Object.values(cities)))
       svg.selectAll("circle")
           .data(
-            response.map(city => Object.values(city)).map(array => {
-              return [-array[0].longitude, array[0].latitude]})
+            response.map(cities => Object.values(cities))
+            // response.map(city => Object.values(city)).map(array => {
+            //   return [-array[0].longitude, array[0].latitude]})
           )
           .enter()
           .append("circle")
-          .attr("cx", d => d[0])
+          .attr("cx", d => projection([d.longitude, d.latitude])[0])
           .attr("cy", d => d[1])
           .attr("r", 5)
           .attr("fill", "red")

--- a/us-map.js
+++ b/us-map.js
@@ -25,5 +25,5 @@ d3.json("http://bl.ocks.org/mbostock/raw/4090846/us.json", (error, us) => {
       .attr("d", path);
 });
 
-getCitiesForState('ca')
-getCitiesForState('ga')
+getCitiesForState('ak')
+// getCitiesForState('ga')


### PR DESCRIPTION
@brittanystoroz I've been stuck on trying to render things according to the projection coordinates and I'm getting the error:  
  city-finder.js:28 TypeError: Cannot read property 'stream' of undefined
    at point (d3.v4.min.js:6)
    at n (albersUsa-min.js:1)
    at SVGCircleElement.svg.selectAll.data.enter.append.attr.d (city-finder.js:21)
    at SVGCircleElement.<anonymous> (d3.v4.min.js:2)
    at dt.ol [as each] (d3.v4.min.js:4)
    at dt.ul [as attr] (d3.v4.min.js:4)
    at fetch.then.then.then.then.then.response (city-finder.js:21)

I don't know how to get around it- at first I was trying to figure out how to do the math and just overlay- but I got stuck on that too- this seemed like a much better idea and I could use the method later...  but what's going wrong?